### PR TITLE
Fixes #11070 - Regression on Calendar's firstDayOfWeek getter

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -597,7 +597,7 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     }
 
     @Input() get firstDayOfWeek(): number {
-        return this._numberOfMonths;
+        return this._firstDayOfWeek;
     }
 
     set firstDayOfWeek(firstDayOfWeek: number) {


### PR DESCRIPTION
Calendar firstDayOfWeek's getter returns the number of months since 13.0.4.